### PR TITLE
[build] support os x

### DIFF
--- a/cmake/icudata.cmake
+++ b/cmake/icudata.cmake
@@ -98,21 +98,42 @@ if (ICU_PKGDATA_EXECUTABLE)
     generate_icudata_resource_bundle(curr ${_ICUDATA_BINARY_DIR}/curr)
     generate_icudata_resource_bundle(unit ${_ICUDATA_BINARY_DIR}/unit)
 
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
-        COMMAND find -not -type d -printf '%P\\n' > ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
-        WORKING_DIRECTORY ${_ICUDATA_BINARY_DIR}
-        DEPENDS ${_ICUDATA_BINARY_DIR}/pool.res
-        DEPENDS ${_ICUDATA_BINARY_DIR}/res_index.res
-        DEPENDS ${resource_bundle_output_files}
-    )
+    if (APPLE)
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+            COMMAND find . -not -type d -print | awk "{print substr($1,3); }" > ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+            WORKING_DIRECTORY ${_ICUDATA_BINARY_DIR}
+            VERBATIM
+            DEPENDS ${_ICUDATA_BINARY_DIR}/pool.res
+            DEPENDS ${_ICUDATA_BINARY_DIR}/res_index.res
+            DEPENDS ${resource_bundle_output_files}
+        )
 
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libicudata.a
-        COMMAND ${ICU_PKGDATA_EXECUTABLE} -q -c -s ${_ICUDATA_BINARY_DIR} -d ${CMAKE_CURRENT_BINARY_DIR} -e icudt63  -T ${CMAKE_CURRENT_BINARY_DIR} -p icudt63l -m static -r 63.1 -L icudata ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/icu4c/source/data
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
-    )
+        add_custom_command(
+                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libicudata.a
+                COMMAND ${ICU_PKGDATA_EXECUTABLE} -q -c -s ${_ICUDATA_BINARY_DIR} -d ${CMAKE_CURRENT_BINARY_DIR} -O ${CMAKE_CURRENT_SOURCE_DIR}/icu4c/source/data/pkgdata.osx.inc -e icudt63  -T ${CMAKE_CURRENT_BINARY_DIR} -p icudt63l -m static -r 63.1 -L icudata ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/icu4c/source/data
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/icu4c/source/data/pkgdata.osx.inc
+        )
+    else()
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+            COMMAND find -not -type d -printf '%P\\n' > ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+            WORKING_DIRECTORY ${_ICUDATA_BINARY_DIR}
+            DEPENDS ${_ICUDATA_BINARY_DIR}/pool.res
+            DEPENDS ${_ICUDATA_BINARY_DIR}/res_index.res
+            DEPENDS ${resource_bundle_output_files}
+        )
+
+        add_custom_command(
+                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libicudata.a
+                COMMAND ${ICU_PKGDATA_EXECUTABLE} -q -c -s ${_ICUDATA_BINARY_DIR} -d ${CMAKE_CURRENT_BINARY_DIR} -e icudt63  -T ${CMAKE_CURRENT_BINARY_DIR} -p icudt63l -m static -r 63.1 -L icudata ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/icu4c/source/data
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/icudata.lst
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/pkgdata.inc
+        )
+    endif()
 
     add_custom_target(icudata-pkgdata ALL
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libicudata.a

--- a/icu4c/source/data/pkgdata.osx.inc
+++ b/icu4c/source/data/pkgdata.osx.inc
@@ -1,0 +1,17 @@
+GENCCODE_ASSEMBLY_TYPE=-a gcc-darwin
+SO=dylib
+SOBJ=dylib
+A=a
+LIBPREFIX=lib
+LIB_EXT_ORDER=.61.1.a
+COMPILE=/usr/bin/clang -DU_ATTRIBUTE_DEPRECATED=   -DU_ENABLE_DYLOAD=0 -DU_HAVE_ATOMIC=1 -DU_HAVE_STRTOD_L=1 -arch x86_64 -mmacosx-version-min=10.8 -DU_CHARSET_IS_UTF8=1 -DU_CHAR_TYPE=uint_least16_t -DU_CHARSET_IS_UTF8=1 -DU_CHAR_TYPE=uint_least16_t -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1 -fvisibility=hidden -g -Os -std=c99 -Wall -pedantic -Wshadow -Wpointer-arith -Wmissing-prototypes -Wwrite-strings   -fno-common -c
+LIBFLAGS=-static
+GENLIB=/usr/bin/clang -staticlib -static -arch x86_64 -mmacosx-version-min=10.8 -DU_CHARSET_IS_UTF8=1 -DU_CHAR_TYPE=uint_least16_t -DU_CHARSET_IS_UTF8=1 -DU_CHAR_TYPE=uint_least16_t -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1 -fvisibility=hidden -g -Os -std=c99 -Wall -pedantic -Wshadow -Wpointer-arith -Wmissing-prototypes -Wwrite-strings   -Wl,-search_paths_first -arch x86_64 -mmacosx-version-min=10.8
+LDICUDTFLAGS=
+LD_SONAME=-Wl,-compatibility_version -Wl,61 -Wl,-current_version -Wl,61.1 -install_name
+RPATH_FLAGS=
+BIR_LDFLAGS=
+AR=libtool
+ARFLAGS=-o
+RANLIB=/usr/bin/ranlib
+INSTALL_CMD=/usr/local/bin/ginstall -c


### PR DESCRIPTION
On OS X we need to use libtool instead of ar to generate the data files. The only way I found to do this is use a (rather cumbersome) include file.

Also fixes the usage of find in case of OS X